### PR TITLE
add Hinweis auf Unentschieden bei 42 gesetzten Steinen

### DIFF
--- a/VierGewinnt/src/Main.java
+++ b/VierGewinnt/src/Main.java
@@ -188,7 +188,7 @@ public class Main {
 							}
 						    stopp1= 0;
 							
-							
+							if(count > 42) System.out.println("Unentschieden");			
 							
 			}	
 		}	


### PR DESCRIPTION
Ich lasse ein Hinweis auf Unentschieden auf die Konsole printen, wenn alle 42 Spielsteine gesetzt wurden. Ich lasse am Ende des Codes überprüfen, ob Count unter 42 ist, wenn nicht -> Hinweis.